### PR TITLE
fix: #122 - remove base64 padding for vapid keys

### DIFF
--- a/generate_config.sh
+++ b/generate_config.sh
@@ -16,8 +16,8 @@ echo "january = \"https://$1/january\"" >> Revolt.toml
 echo "" >> Revolt.toml
 echo "[pushd.vapid]" >> Revolt.toml
 openssl ecparam -name prime256v1 -genkey -noout -out vapid_private.pem
-echo "private_key = \"$(base64 -i vapid_private.pem | tr -d '\n')\"" >> Revolt.toml
-echo "public_key = \"$(openssl ec -in vapid_private.pem -outform DER|tail -c 65|base64|tr '/+' '_-'|tr -d '\n')\"" >> Revolt.toml
+echo "private_key = \"$(base64 -i vapid_private.pem | tr -d '\n' | tr -d '=')\"" >> Revolt.toml
+echo "public_key = \"$(openssl ec -in vapid_private.pem -outform DER|tail -c 65|base64|tr '/+' '_-'|tr -d '\n'|tr -d '=')\"" >> Revolt.toml
 rm vapid_private.pem
 
 # encryption key for files


### PR DESCRIPTION
this is a fix for issue #122
./generate_config.sh was not stripping base64 padding (=) which would lead to pushd crashing
appending `tr -d '='` solves this